### PR TITLE
test method exists base on signature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,11 +274,12 @@ impl AutoCfg {
     /// The test code is subject to change, but currently looks like:
     ///
     /// ```ignore
-    /// pub static PROBE: SIG = METHOD;
+    /// pub fn probe() {
+    ///     let _: SIG = METHOD;
+    /// }
     /// ```
     pub fn probe_method(&self, name: &str, sig: &str) -> bool {
-        self.probe(format!("pub static PROBE: {} = {};", sig, name))
-            .unwrap_or(false)
+        self.probe_expr(name, sig)
     }
 
     /// Emits a config value `has_METHOD` if `probe_method` returns true.
@@ -289,6 +290,20 @@ impl AutoCfg {
         if self.probe_method(name, sig) {
             emit(&format!("has_{}", mangle(name)));
         }
+    }
+
+    /// Tests whether the given expression can be used.
+    ///
+    /// The test code is subject to change, but currently looks like:
+    ///
+    /// ```ignore
+    /// pub fn probe() {
+    ///     let _: TYPE = EXPR;
+    /// }
+    /// ```
+    pub fn probe_expr(&self, expr: &str, ty: &str) -> bool {
+        self.probe(format!("pub fn probe() {{ let _: {} = {}; }}", ty, expr))
+            .unwrap_or(false)
     }
 
     /// Emits the given `cfg` value if `probe_type` returns true.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -62,3 +62,16 @@ fn probe_int_to_from_bytes() {
     let missing = !ac.probe_rustc_version(1, 32);
     assert!(missing ^ ac.probe_method("usize::to_ne_bytes", stringify!(fn(usize) -> [u8; 8])));
 }
+
+#[test]
+fn probe_expr() {
+    let ac = AutoCfg::with_dir("target").unwrap();
+    let missing = !ac.probe_rustc_version(1, 13);
+    assert!(
+        missing
+            ^ ac.probe_expr(
+                stringify!(|| Ok(std::env::current_dir()?)),
+                stringify!(fn() -> std::io::Result<std::path::PathBuf>)
+            )
+    );
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -55,3 +55,10 @@ fn probe_sum() {
     assert!(missing ^ ac.probe_trait("std::iter::Sum<i32>"));
     assert!(missing ^ ac.probe_type("std::iter::Sum<i32>"));
 }
+
+#[test]
+fn probe_int_to_from_bytes() {
+    let ac = AutoCfg::with_dir("target").unwrap();
+    let missing = !ac.probe_rustc_version(1, 22);
+    assert!(missing ^ ac.probe_method("usize::to_ne_bytes", "fn(usize) -> [u8; 8]"));
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -60,5 +60,5 @@ fn probe_sum() {
 fn probe_int_to_from_bytes() {
     let ac = AutoCfg::with_dir("target").unwrap();
     let missing = !ac.probe_rustc_version(1, 22);
-    assert!(missing ^ ac.probe_method("usize::to_ne_bytes", "fn(usize) -> [u8; 8]"));
+    assert!(missing ^ ac.probe_method("usize::to_ne_bytes", stringify!(fn(usize) -> [u8; 8])));
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -59,6 +59,6 @@ fn probe_sum() {
 #[test]
 fn probe_int_to_from_bytes() {
     let ac = AutoCfg::with_dir("target").unwrap();
-    let missing = !ac.probe_rustc_version(1, 22);
+    let missing = !ac.probe_rustc_version(1, 32);
     assert!(missing ^ ac.probe_method("usize::to_ne_bytes", stringify!(fn(usize) -> [u8; 8])));
 }


### PR DESCRIPTION
I'm not sure whether or not we can use the type parameter to dump as function signature.

```rust
pub fn probe_method<SIG>(&self, name: &str) -> bool {
    self.probe(format!("pub static PROBE: {} = {};", some_magic!(SIG), name))
        .unwrap_or(false)
}
```

seems [std::intrinsics::type_name](https://doc.rust-lang.org/std/intrinsics/fn.type_name.html) is not stable.