### PR TITLE
Release 0.1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ matrix:
         - rustup target add $TARGET
       script:
         - cargo test --verbose --lib -- no_std
+    # we don't even need an installed target for version checks
+    - name: "missing_target"
+      rust: stable
+      env: TARGET=thumbv6m-none-eabi
+      script:
+        - cargo test --verbose --lib -- version
     - name: "rustfmt"
       rust: 1.31.0
       before_script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autocfg"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Josh Stone <cuviper@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/cuviper/autocfg"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ should only be used when the compiler supports it.
 
 ## Release Notes
 
+- 0.1.4 (2019-05-22)
+  - Relax `std`/`no_std` probing to a warning instead of an error.
+  - Improve `rustc` bootstrap compatibility.
+
 - 0.1.3 (2019-05-21)
   - Auto-detects if `#![no_std]` is needed for the `$TARGET`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,8 @@ impl AutoCfg {
         let id = ID.fetch_add(1, Ordering::Relaxed);
         let mut command = Command::new(&self.rustc);
         command
-            .arg(format!("--crate-name=probe{}", id))
+            .arg("--crate-name")
+            .arg(format!("probe{}", id))
             .arg("--crate-type=lib")
             .arg("--out-dir")
             .arg(&self.out_dir)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 use std::env;
 use std::ffi::OsString;
 use std::fs;
-use std::io::Write;
+use std::io::{stderr, Write};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 #[allow(deprecated)]
@@ -153,7 +153,11 @@ impl AutoCfg {
         if !try!(ac.probe("")) {
             ac.no_std = true;
             if !try!(ac.probe("")) {
-                return Err(error::from_str("could not probe for `std`"));
+                // Neither worked, so assume nothing...
+                ac.no_std = false;
+                stderr()
+                    .write_all(b"warning: autocfg could not probe for `std`")
+                    .ok();
             }
         }
         Ok(ac)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,14 +150,13 @@ impl AutoCfg {
         };
 
         // Sanity check with and without `std`.
-        if !try!(ac.probe("")) {
+        if !ac.probe("").unwrap_or(false) {
             ac.no_std = true;
-            if !try!(ac.probe("")) {
+            if !ac.probe("").unwrap_or(false) {
                 // Neither worked, so assume nothing...
                 ac.no_std = false;
-                stderr()
-                    .write_all(b"warning: autocfg could not probe for `std`")
-                    .ok();
+                let warning = b"warning: autocfg could not probe for `std`\n";
+                stderr().write_all(warning).ok();
             }
         }
         Ok(ac)


### PR DESCRIPTION
  - Relax `std`/`no_std` probing to a warning instead of an error.
  - Improve `rustc` bootstrap compatibility.