### PR TITLE
Add arguments from RUSTFLAGS to the rustc command.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ keywords = ["rustc", "build", "autoconf"]
 categories = ["development-tools::build-utils"]
 
 [dependencies]
+shlex = "0.1.1"


### PR DESCRIPTION
This fixes feature probing in cross-compilation environments, for example using Yocto and its meta-rust layer.
`RUSTFLAGS` is supported by cargo to pass flags to all rustc invocations. Yocto uses it to pass the library search path of the target sysroot, which is required to compile anything for the given target.

I'm using the shlex crate to properly parse arguments in RUSTFLAGS, also those containing whitespaces.

@cuviper This is a follow-up to my E-Mail from yesterday and solves my build problem under Yocto properly. Please release new versions of `autocfg` and `num-bigint` soon to get this problem fixed for the mass.