### PR TITLE
Compatible with cargo --remap-path-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fn main() {
     ac.emit_has_type("i128");
 
     // (optional) We don't need to rerun for anything external.
-    autocfg::rerun_path(file!());
+    autocfg::rerun_path("build.rs");
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!     ac.emit_has_type("i128");
 //!
 //!     // (optional) We don't need to rerun for anything external.
-//!     autocfg::rerun_path(file!());
+//!     autocfg::rerun_path("build.rs");
 //! }
 //! ```
 //!


### PR DESCRIPTION
As discussed in [num-traits issue 139](https://github.com/rust-num/num-traits/issues/139).