### PR TITLE
Use TESTS_TARGET_DIR envvar to override tests target dir

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use super::AutoCfg;
+use std::env;
 
 impl AutoCfg {
     fn core_std(&self, path: &str) -> String {
@@ -13,11 +14,18 @@ impl AutoCfg {
     fn assert_min(&self, major: usize, minor: usize, probe_result: bool) {
         assert_eq!(self.probe_rustc_version(major, minor), probe_result);
     }
+
+    fn for_test() -> Result<Self, super::error::Error> {
+        match env::var_os("TESTS_TARGET_DIR") {
+            Some(d) => Self::with_dir(d),
+            None => Self::with_dir("target"),
+        }
+    }
 }
 
 #[test]
 fn autocfg_version() {
-    let ac = AutoCfg::with_dir("target").unwrap();
+    let ac = AutoCfg::for_test().unwrap();
     println!("version: {:?}", ac.rustc_version);
     assert!(ac.probe_rustc_version(1, 0));
 }
@@ -37,7 +45,7 @@ fn version_cmp() {
 
 #[test]
 fn probe_add() {
-    let ac = AutoCfg::with_dir("target").unwrap();
+    let ac = AutoCfg::for_test().unwrap();
     let add = ac.core_std("ops::Add");
     let add_rhs = add.clone() + "<i32>";
     let add_rhs_output = add.clone() + "<i32, Output = i32>";
@@ -51,7 +59,7 @@ fn probe_add() {
 
 #[test]
 fn probe_as_ref() {
-    let ac = AutoCfg::with_dir("target").unwrap();
+    let ac = AutoCfg::for_test().unwrap();
     let as_ref = ac.core_std("convert::AsRef");
     let as_ref_str = as_ref.clone() + "<str>";
     let dyn_as_ref_str = "dyn ".to_string() + &*as_ref_str;
@@ -63,7 +71,7 @@ fn probe_as_ref() {
 
 #[test]
 fn probe_i128() {
-    let ac = AutoCfg::with_dir("target").unwrap();
+    let ac = AutoCfg::for_test().unwrap();
     let i128_path = ac.core_std("i128");
     ac.assert_min(1, 26, ac.probe_path(&i128_path));
     ac.assert_min(1, 26, ac.probe_type("i128"));
@@ -71,7 +79,7 @@ fn probe_i128() {
 
 #[test]
 fn probe_sum() {
-    let ac = AutoCfg::with_dir("target").unwrap();
+    let ac = AutoCfg::for_test().unwrap();
     let sum = ac.core_std("iter::Sum");
     let sum_i32 = sum.clone() + "<i32>";
     let dyn_sum_i32 = "dyn ".to_string() + &*sum_i32;
@@ -84,25 +92,25 @@ fn probe_sum() {
 
 #[test]
 fn probe_std() {
-    let ac = AutoCfg::with_dir("target").unwrap();
+    let ac = AutoCfg::for_test().unwrap();
     ac.assert_std(ac.probe_sysroot_crate("std"));
 }
 
 #[test]
 fn probe_alloc() {
-    let ac = AutoCfg::with_dir("target").unwrap();
+    let ac = AutoCfg::for_test().unwrap();
     ac.assert_min(1, 36, ac.probe_sysroot_crate("alloc"));
 }
 
 #[test]
 fn probe_bad_sysroot_crate() {
-    let ac = AutoCfg::with_dir("target").unwrap();
+    let ac = AutoCfg::for_test().unwrap();
     assert!(!ac.probe_sysroot_crate("doesnt_exist"));
 }
 
 #[test]
 fn probe_no_std() {
-    let ac = AutoCfg::with_dir("target").unwrap();
+    let ac = AutoCfg::for_test().unwrap();
     assert!(ac.probe_type("i32"));
     assert!(ac.probe_type("[i32]"));
     ac.assert_std(ac.probe_type("Vec<i32>"));
@@ -110,7 +118,7 @@ fn probe_no_std() {
 
 #[test]
 fn probe_expression() {
-    let ac = AutoCfg::with_dir("target").unwrap();
+    let ac = AutoCfg::for_test().unwrap();
     assert!(ac.probe_expression(r#""test".trim_left()"#));
     ac.assert_min(1, 30, ac.probe_expression(r#""test".trim_start()"#));
     ac.assert_std(ac.probe_expression("[1, 2, 3].to_vec()"));
@@ -118,7 +126,7 @@ fn probe_expression() {
 
 #[test]
 fn probe_constant() {
-    let ac = AutoCfg::with_dir("target").unwrap();
+    let ac = AutoCfg::for_test().unwrap();
     assert!(ac.probe_constant("1 + 2 + 3"));
     ac.assert_min(1, 33, ac.probe_constant("{ let x = 1 + 2 + 3; x * x }"));
     ac.assert_min(1, 39, ac.probe_constant(r#""test".len()"#));


### PR DESCRIPTION
Rationale: At Debian, the autopkgtests are run inside a non-writable
directory, so the "target" subdirectory can't be used. Inside the
autopkgtest environment, we have an env variable AUTOPKGTEST_TMP
available which points to a temporary directory, that we can pass on to
the tests as TESTS_TARGET_DIR. This makes the tests pass properly inside
this environment.
