### PR TITLE
Try to determine if --target was passed to Cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Josh Stone <cuviper@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/cuviper/autocfg"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ should only be used when the compiler supports it.
 
 ## Release Notes
 
+- 1.0.1 (2020-08-20)
+  - Apply `RUSTFLAGS` for more `--target` scenarios, by @adamreichold.
+
 - 1.0.0 (2020-01-08)
   - 🎉 Release 1.0! 🎉 (no breaking changes)
   - Add `probe_expression` and `emit_expression_cfg` to test arbitrary expressions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,8 @@ impl AutoCfg {
         let rustc: PathBuf = rustc.into();
         let rustc_version = try!(Version::from_rustc(&rustc));
 
+        let target = env::var_os("TARGET");
+
         // Sanity check the output directory
         let dir = dir.into();
         let meta = try!(fs::metadata(&dir).map_err(error::from_io));
@@ -170,7 +172,23 @@ impl AutoCfg {
         // so for now we only apply RUSTFLAGS when cross-compiling an artifact.
         //
         // See https://github.com/cuviper/autocfg/pull/10#issuecomment-527575030.
-        let rustflags = if env::var_os("TARGET") != env::var_os("HOST") {
+        let dir_contains_target = target
+            .as_ref()
+            .and_then(|target| {
+                dir.to_str().and_then(|dir| {
+                    let mut cargo_target_dir = env::var_os("CARGO_TARGET_DIR")
+                        .map(PathBuf::from)
+                        .unwrap_or_else(|| PathBuf::from("target"));
+                    cargo_target_dir.push(target);
+
+                    cargo_target_dir
+                        .to_str()
+                        .map(|cargo_target_dir| dir.contains(&cargo_target_dir))
+                })
+            })
+            .unwrap_or(false);
+
+        let rustflags = if target != env::var_os("HOST") || dir_contains_target {
             env::var("RUSTFLAGS").ok().map(|rustflags| {
                 // This is meant to match how cargo handles the RUSTFLAG environment
                 // variable.
@@ -190,7 +208,7 @@ impl AutoCfg {
             out_dir: dir,
             rustc: rustc,
             rustc_version: rustc_version,
-            target: env::var_os("TARGET"),
+            target: target,
             no_std: false,
             rustflags: rustflags,
         };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -131,3 +131,39 @@ fn probe_constant() {
     ac.assert_min(1, 33, ac.probe_constant("{ let x = 1 + 2 + 3; x * x }"));
     ac.assert_min(1, 39, ac.probe_constant(r#""test".len()"#));
 }
+
+#[test]
+fn dir_does_not_contain_target() {
+    assert!(!super::dir_contains_target(
+        &Some("x86_64-unknown-linux-gnu".into()),
+        &"/project/target/debug/build/project-ea75983148559682/out".into(),
+        None,
+    ));
+}
+
+#[test]
+fn dir_does_contain_target() {
+    assert!(super::dir_contains_target(
+        &Some("x86_64-unknown-linux-gnu".into()),
+        &"/project/target/x86_64-unknown-linux-gnu/debug/build/project-0147aca016480b9d/out".into(),
+        None,
+    ));
+}
+
+#[test]
+fn dir_does_not_contain_target_with_custom_target_dir() {
+    assert!(!super::dir_contains_target(
+        &Some("x86_64-unknown-linux-gnu".into()),
+        &"/project/custom/debug/build/project-ea75983148559682/out".into(),
+        Some("custom".into()),
+    ));
+}
+
+#[test]
+fn dir_does_contain_target_with_custom_target_dir() {
+    assert!(super::dir_contains_target(
+        &Some("x86_64-unknown-linux-gnu".into()),
+        &"/project/custom/x86_64-unknown-linux-gnu/debug/build/project-0147aca016480b9d/out".into(),
+        Some("custom".into()),
+    ));
+}


### PR DESCRIPTION
This checks the output directory for the `$CARGO_TARGET_DIR/$TARGET` pattern making use of `MAIN_SEPARATOR` to try to handle Windows. It will also fail if either the path or that pattern are not valid UFT-8, but it will then fall back to the current behavior. (So this basically tries to implement https://github.com/cuviper/autocfg/pull/10#issuecomment-527575030.)