### PR TITLE
Hide rustc output by default.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,9 @@ impl AutoCfg {
         }
 
         command.arg("-").stdin(Stdio::piped());
+        if env::var_os("AUTOCFG_SHOW_RUSTC_OUTPUT").is_none() {
+            command.stderr(Stdio::null());
+        }
         let mut child = try!(command.spawn().map_err(error::from_io));
         let mut stdin = child.stdin.take().expect("rustc stdin");
 


### PR DESCRIPTION
But add an environment variable to allow showing it, if wanted.

Fixes #30