### PR TITLE
Probe rustc channel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ mod error;
 pub use error::Error;
 
 mod version;
+pub use version::Channel;
 use version::Version;
 
 #[cfg(test)]
@@ -84,6 +85,7 @@ pub struct AutoCfg {
     out_dir: PathBuf,
     rustc: PathBuf,
     rustc_version: Version,
+    rustc_channel: Channel,
     target: Option<OsString>,
     no_std: bool,
     rustflags: Option<Vec<String>>,
@@ -155,7 +157,7 @@ impl AutoCfg {
     pub fn with_dir<T: Into<PathBuf>>(dir: T) -> Result<Self, Error> {
         let rustc = env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
         let rustc: PathBuf = rustc.into();
-        let rustc_version = try!(Version::from_rustc(&rustc));
+        let (rustc_version, rustc_channel) = try!(version::version_and_channel_from_rustc(&rustc));
 
         let target = env::var_os("TARGET");
 
@@ -194,6 +196,7 @@ impl AutoCfg {
             out_dir: dir,
             rustc: rustc,
             rustc_version: rustc_version,
+            rustc_channel: rustc_channel,
             target: target,
             no_std: false,
             rustflags: rustflags,
@@ -403,6 +406,11 @@ impl AutoCfg {
         if self.probe_constant(expr) {
             emit(cfg);
         }
+    }
+
+    /// Returns the current `rustc` [`Channel`].
+    pub fn rustc_channel(&self) -> Channel {
+        self.rustc_channel
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,7 +475,7 @@ impl AutoCfg {
     /// This removes `#![feature(<feature>)]` from the start of all probes on nightly `rustc`
     /// channels. If the feature was not set, this does nothing.
     pub fn unset_feature(&mut self, feature: &str) {
-        self.features.remove(mangle(feature));
+        self.features.remove(&mangle(feature));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,6 +412,28 @@ impl AutoCfg {
     pub fn rustc_channel(&self) -> Channel {
         self.rustc_channel
     }
+
+    /// Tests whether the current `rustc` [`Channel`] supports the features of the requested
+    /// `channel`.
+    pub fn probe_rustc_channel(&self, channel: Channel) -> bool {
+        self.rustc_channel >= channel
+    }
+
+    /// Emits a `cfg` value of the form `rustc_channel_<channel>, like `rustc_channel_nightly`, if
+    /// the current `rustc` [`Channel`] supports the features of the requested `channel`.
+    pub fn emit_rustc_channel(&self, channel: Channel) {
+        if self.probe_rustc_channel(channel) {
+            emit(&format!(
+                "rustc_channel_{}",
+                match channel {
+                    Channel::Stable => "stable",
+                    Channel::Beta => "beta",
+                    Channel::Nightly => "nightly",
+                    Channel::Dev => "dev",
+                }
+            ))
+        }
+    }
 }
 
 fn mangle(s: &str) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,9 @@ impl AutoCfg {
             try!(stdin.write_all(b"#![no_std]\n").map_err(error::from_io));
         }
         for feature in &self.features {
-            try!(stdin.write_all(format!("#![feature({})]\n", feature).as_bytes()).map_err(error::from_io));
+            try!(stdin
+                .write_all(format!("#![feature({})]\n", feature).as_bytes())
+                .map_err(error::from_io));
         }
         try!(stdin.write_all(code.as_ref()).map_err(error::from_io));
         drop(stdin);
@@ -444,7 +446,8 @@ impl AutoCfg {
     /// Tests whether `feature` is an available feature gate.
     pub fn probe_feature(&self, feature: &str) -> bool {
         if self.probe_rustc_channel(Channel::Nightly) {
-            self.probe(format!("#![feature({})]", mangle(feature))).unwrap_or(false)
+            self.probe(format!("#![feature({})]", mangle(feature)))
+                .unwrap_or(false)
         } else {
             // Features are only supported on nightly channels.
             false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,6 +434,23 @@ impl AutoCfg {
             ))
         }
     }
+
+    /// Tests whether `feature` is an available feature gate.
+    pub fn probe_feature(&self, feature: &str) -> bool {
+        if self.probe_rustc_channel(Channel::Nightly) {
+            self.probe(format!("#![feature({})]", mangle(feature))).unwrap_or(false)
+        } else {
+            // Features are only supported on nightly channels.
+            false
+        }
+    }
+
+    /// Emits the given `cfg` if `feature` is an available feature gate.
+    pub fn emit_feature_cfg(&self, feature: &str, cfg: &str) {
+        if self.probe_feature(feature) {
+            emit(cfg)
+        }
+    }
 }
 
 fn mangle(s: &str) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,7 +466,7 @@ impl AutoCfg {
     /// On non-nightly channels this does nothing.
     pub fn set_feature(&mut self, feature: &str) {
         if self.probe_feature(feature) {
-            self.features.insert(feature.to_owned());
+            self.features.insert(mangle(feature));
         }
     }
 
@@ -475,7 +475,7 @@ impl AutoCfg {
     /// This removes `#![feature(<feature>)]` from the start of all probes on nightly `rustc`
     /// channels. If the feature was not set, this does nothing.
     pub fn unset_feature(&mut self, feature: &str) {
-        self.features.remove(feature);
+        self.features.remove(mangle(feature));
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
 use super::AutoCfg;
 use super::Channel;
-use super::Version;
+use super::version::Version;
 use std::env;
 
 impl AutoCfg {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -189,6 +189,17 @@ fn probe_dev() {
 }
 
 #[test]
+fn probe_feature() {
+    let ac = AutoCfg::for_test().unwrap();
+
+    assert!(!ac.probe_feature("nonexistant_feature_abcdefg"));
+    // rust1 is the feature gate for Rust 1.0.
+    ac.assert_on_channel(Channel::Stable, !ac.probe_feature("rust1"));
+    ac.assert_on_channel(Channel::Beta, !ac.probe_feature("rust1"));
+    ac.assert_on_channel(Channel::Nightly, ac.probe_feature("rust1"));
+}
+
+#[test]
 fn dir_does_not_contain_target() {
     assert!(!super::dir_contains_target(
         &Some("x86_64-unknown-linux-gnu".into()),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
+use super::version::Version;
 use super::AutoCfg;
 use super::Channel;
-use super::version::Version;
 use std::env;
 
 impl AutoCfg {
@@ -202,7 +202,7 @@ fn probe_feature() {
 #[test]
 fn set_feature() {
     let mut ac = AutoCfg::for_test().unwrap();
-    let step_trait =  ac.core_std("iter::Step");
+    let step_trait = ac.core_std("iter::Step");
 
     ac.set_feature("step_trait");
     // As of Rust 1.50, the Step trait is experimental and therefore unaccessible on stable. Setting

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use super::AutoCfg;
+use super::Channel;
 use std::env;
 
 impl AutoCfg {
@@ -31,6 +32,12 @@ fn autocfg_version() {
 }
 
 #[test]
+fn autocfg_channel() {
+    let ac = AutoCfg::for_test().unwrap();
+    assert!(ac.probe_rustc_channel(Channel::Stable));
+}
+
+#[test]
 fn version_cmp() {
     use super::version::Version;
     let v123 = Version::new(1, 2, 3);
@@ -41,6 +48,13 @@ fn version_cmp() {
     assert!(Version::new(1, 2, 4) > v123);
     assert!(Version::new(1, 10, 0) > v123);
     assert!(Version::new(2, 0, 0) > v123);
+}
+
+#[test]
+fn channel_cmp() {
+    assert!(Channel::Stable < Channel::Beta);
+    assert!(Channel::Beta < Channel::Nightly);
+    assert!(Channel::Nightly < Channel::Dev);
 }
 
 #[test]

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::path::Path;
 use std::process::Command;
 use std::str;
@@ -5,16 +6,32 @@ use std::str;
 use super::{error, Error};
 
 /// The channel the current compiler was released on.
+///
+/// `Channel`s are orderable by their available features. The more features a channel supports, the
+/// higher it is ordered. Specifically, channels are ordered as follows: `Stable < Beta < Nightly <
+/// Dev`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Channel {
     /// Stable channel.
     Stable,
-    /// Beta channel, one release ahead of stable.
+    /// Beta channel.
     Beta,
-    /// Nightly channel, released every night.
+    /// Nightly channel.
     Nightly,
     /// Dev channel.
     Dev,
+}
+
+impl PartialOrd<Channel> for Channel {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        (*self as u8).partial_cmp(&(*other as u8))
+    }
+}
+
+impl Ord for Channel {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (*self as u8).cmp(&(*other as u8))
+    }
 }
 
 /// A version structure for making relative comparisons.

--- a/src/version.rs
+++ b/src/version.rs
@@ -4,6 +4,19 @@ use std::str;
 
 use super::{error, Error};
 
+/// The channel the current compiler was released on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Channel {
+    /// Stable channel.
+    Stable,
+    /// Beta channel, one release ahead of stable.
+    Beta,
+    /// Nightly channel, released every night.
+    Nightly,
+    /// Dev channel.
+    Dev,
+}
+
 /// A version structure for making relative comparisons.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Version {
@@ -21,40 +34,57 @@ impl Version {
             patch: patch,
         }
     }
+}
 
-    pub fn from_rustc(rustc: &Path) -> Result<Self, Error> {
-        // Get rustc's verbose version
-        let output = try!(Command::new(rustc)
-            .args(&["--version", "--verbose"])
-            .output()
-            .map_err(error::from_io));
-        if !output.status.success() {
-            return Err(error::from_str("could not execute rustc"));
+pub fn version_and_channel_from_rustc(rustc: &Path) -> Result<(Version, Channel), Error> {
+    // Get rustc's verbose version
+    let output = try!(Command::new(rustc)
+        .args(&["--version", "--verbose"])
+        .output()
+        .map_err(error::from_io));
+    if !output.status.success() {
+        return Err(error::from_str("could not execute rustc"));
+    }
+    let output = try!(str::from_utf8(&output.stdout).map_err(error::from_utf8));
+
+    // Find the release line in the verbose version output.
+    let release = match output.lines().find(|line| line.starts_with("release: ")) {
+        Some(line) => &line["release: ".len()..],
+        None => return Err(error::from_str("could not find rustc release")),
+    };
+
+    let mut release_split = release.split('-');
+    let version = match release_split.next() {
+        Some(version) => version,
+        None => return Err(error::from_str("could not parse rustc release")),
+    };
+    let channel = match release_split.next() {
+        Some(channel) => {
+            if channel.starts_with("beta") {
+                Channel::Beta
+            } else if channel.starts_with("nightly") {
+                Channel::Nightly
+            } else if channel.starts_with("dev") {
+                Channel::Dev
+            } else {
+                return Err(error::from_str("could not parse rustc channel"));
+            }
         }
-        let output = try!(str::from_utf8(&output.stdout).map_err(error::from_utf8));
+        None => Channel::Stable,
+    };
 
-        // Find the release line in the verbose version output.
-        let release = match output.lines().find(|line| line.starts_with("release: ")) {
-            Some(line) => &line["release: ".len()..],
-            None => return Err(error::from_str("could not find rustc release")),
-        };
+    // Split the version into semver components.
+    let mut iter = version.splitn(3, '.');
+    let major = try!(iter.next().ok_or(error::from_str("missing major version")));
+    let minor = try!(iter.next().ok_or(error::from_str("missing minor version")));
+    let patch = try!(iter.next().ok_or(error::from_str("missing patch version")));
 
-        // Strip off any extra channel info, e.g. "-beta.N", "-nightly"
-        let version = match release.find('-') {
-            Some(i) => &release[..i],
-            None => release,
-        };
-
-        // Split the version into semver components.
-        let mut iter = version.splitn(3, '.');
-        let major = try!(iter.next().ok_or(error::from_str("missing major version")));
-        let minor = try!(iter.next().ok_or(error::from_str("missing minor version")));
-        let patch = try!(iter.next().ok_or(error::from_str("missing patch version")));
-
-        Ok(Version::new(
+    Ok((
+        Version::new(
             try!(major.parse().map_err(error::from_num)),
             try!(minor.parse().map_err(error::from_num)),
             try!(patch.parse().map_err(error::from_num)),
-        ))
-    }
+        ),
+        channel,
+    ))
 }


### PR DESCRIPTION
This PR introduces the ability to probe for the current channel (stable, beta, nightly, dev). It is a solution for issue #28 and also addresses some functionality requested in issue #24.

Firstly, this PR introduces a `Channel` enum, stored in `AutoCfg`, denoting which channel is being used. `PartialOrd` and `Ord` are also defined on this enum, where ordering is defined by available features. In other words, a channel is defined to be "less than" another channel if it contains a subset of available features. So, the channels would be ordered like `Stable < Beta < Nightly < Dev`.

Secondly, there are seven methods added to `AutoCfg`. They are:

- **`rustc_channel()`** - Accessor method to the current `Channel`. I was on the fence about exposing this, since the current `Version` is not actually exposed directly, but I thought it could be useful for users to be able to directly `match` against it. I'm open to any thoughts on this :)
- **`probe_rustc_channel()`** - To test whether the current `Channel` supports the provided `Channel`. For example, `ac.probe_rustc_channel(Stable)` will always be true, but `ac.probe_rustc_channel(Nightly)` will only be true on `nightly` and `dev` channels.
- **`emit_rustc_channel()`** - Same concept as above, but emits a `cfg` if the probe is true.
- **`probe_feature()`** - To test whether a feature can be set. Will always return false if not on nightly or dev.
- **`emit_feature_cfg()`** - Emits a `cfg` if the feature is available.
- **`set_feature()`** - Sets a feature to be allowed before each subsequent probe. Basically the same idea as what is being done with `no_std` in #27. This doesn't do anything on stable/beta channels, which is good as it allows probes to succeed still if running on a later rustc version where the desired feature may have already been stabilized.
- **`unset_feature()`** - Removes a feature that has been set. I'm not sure how useful this will be, as I don't know what benefit could be provided by adding a feature and then later removing it, but it was really easy to add on.

This seemed like the best API for interacting with nightly features. If the API addition is too large, it might make sense to just expose `set_feature()` and `unset_feature()`, since the real end-goal is for users to be able to probe the functionality *provided by* the feature, but it seemed like there is some interest in users probing the features, or even the channel itself, directly. I'm definitely up for discussion on this.