### PR TITLE
Enabling and disabling features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,9 @@ impl AutoCfg {
             try!(stdin.write_all(b"#![no_std]\n").map_err(error::from_io));
         }
         for feature in &self.features {
-            try!(stdin.write_all(format!("#![feature({})]", feature).as_bytes()).map_err(error::from_io));
+            try!(stdin
+                .write_all(format!("#![feature({})]", feature).as_bytes())
+                .map_err(error::from_io));
         }
         try!(stdin.write_all(code.as_ref()).map_err(error::from_io));
         drop(stdin);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -19,11 +19,13 @@ impl AutoCfg {
     fn assert_nightly(&self, probe_result: bool) {
         let output = Command::new(&self.rustc)
             .args(&["--version", "--verbose"])
-            .output().expect("could not parse rustc channel");
+            .output()
+            .expect("could not parse rustc channel");
         if !output.status.success() {
             panic!("could not execute rustc");
         }
-        let output = std::str::from_utf8(&output.stdout).expect("rustc version output was not valid utf8");
+        let output =
+            std::str::from_utf8(&output.stdout).expect("rustc version output was not valid utf8");
         let release = match output.lines().find(|line| line.starts_with("release: ")) {
             Some(line) => &line["release: ".len()..],
             None => panic!("could not find rustc release"),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,7 @@
 use super::AutoCfg;
 use std::env;
 use std::process::Command;
+use std::str;
 
 impl AutoCfg {
     fn core_std(&self, path: &str) -> String {
@@ -17,15 +18,20 @@ impl AutoCfg {
     }
 
     fn assert_nightly(&self, probe_result: bool) {
-        let output = Command::new(&self.rustc)
+        let output = match Command::new(&self.rustc)
             .args(&["--version", "--verbose"])
             .output()
-            .expect("could not parse rustc channel");
+        {
+            Ok(value) => value,
+            Err(error) => panic!(error),
+        };
         if !output.status.success() {
             panic!("could not execute rustc");
         }
-        let output =
-            std::str::from_utf8(&output.stdout).expect("rustc version output was not valid utf8");
+        let output = match str::from_utf8(&output.stdout) {
+            Ok(value) => value,
+            Err(error) => panic!(error),
+        };
         let release = match output.lines().find(|line| line.starts_with("release: ")) {
             Some(line) => &line["release: ".len()..],
             None => panic!("could not find rustc release"),


### PR DESCRIPTION
Second attempt at probing with features. First attempt was #33. 

This PR adds two methods to `AutoCfg`: `enable_feature()`, which enables a nightly feature to be used in probes, and `disable_feature()`, which disables a nightly feature in probes. Specifically, it adds `#![feature(<feature>)]` at the start of subsequent probes.

This API change should be sufficient to allow users to probe whether nightly-only features will work as expected (see requests for this kind of stuff in #24 and #28). The following example will be possible with this PR:

```rust
let mut ac = autocfg::new();
ac.enable_feature("step_trait");
// With the feature enabled, probes will include `#![feature(step_trait)]`.
ac.emit_has_trait("std::iter::Step")
ac.disable_feature("step_trait);
// Further probes will no longer set the feature.
```

Note that when enabling features on `stable` or `beta` channels, any subsequent probes will fail until the feature is disabled.

This seems to be the most direct solution. Users who want to probe for the `rustc` channel or the presence of a nightly feature  should ascertain that the nightly feature they wish to enable works correctly. See the discussion in #33 for why probing for `rustc` channel and probing features directly are not included here.