### PR TITLE
Check `CARGO_ENCODED_RUSTFLAGS` of cargo 1.55+, prefer over `RUSTFLAGS`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,17 +175,20 @@ impl AutoCfg {
         let rustflags = if target != env::var_os("HOST")
             || dir_contains_target(&target, &dir, env::var_os("CARGO_TARGET_DIR"))
         {
-            env::var("RUSTFLAGS").ok().map(|rustflags| {
-                // This is meant to match how cargo handles the RUSTFLAG environment
-                // variable.
-                // See https://github.com/rust-lang/cargo/blob/69aea5b6f69add7c51cca939a79644080c0b0ba0/src/cargo/core/compiler/build_context/target_info.rs#L434-L441
-                rustflags
-                    .split(' ')
-                    .map(str::trim)
-                    .filter(|s| !s.is_empty())
-                    .map(str::to_string)
-                    .collect::<Vec<String>>()
-            })
+            env::var("CARGO_ENCODED_RUSTFLAGS")
+                .or_else(|_| env::var("RUSTFLAGS"))
+                .ok()
+                .map(|rustflags| {
+                    // This is meant to match how cargo handles the RUSTFLAG environment
+                    // variable.
+                    // See https://github.com/rust-lang/cargo/blob/69aea5b6f69add7c51cca939a79644080c0b0ba0/src/cargo/core/compiler/build_context/target_info.rs#L434-L441
+                    rustflags
+                        .split(' ')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string)
+                        .collect::<Vec<String>>()
+                })
         } else {
             None
         };

--- a/tests/rustflags.rs
+++ b/tests/rustflags.rs
@@ -5,10 +5,21 @@ use std::env;
 /// Tests that autocfg uses the RUSTFLAGS environment variable when running
 /// rustc.
 #[test]
-fn test_with_sysroot() {
+fn test_with_sysroot_rustflags() {
+    test_with_sysroot("RUSTFLAGS")
+}
+
+/// Tests that autocfg uses the CARGO_ENCODED_RUSTFLAGS environment
+/// variable when running rustc.
+#[test]
+fn test_with_sysroot_cargo_encoded_rustflags() {
+    test_with_sysroot("CARGO_ENCODED_RUSTFLAGS")
+}
+
+fn test_with_sysroot(var_name: &str) {
     // Use the same path as this test binary.
     let dir = env::current_exe().unwrap().parent().unwrap().to_path_buf();
-    env::set_var("RUSTFLAGS", &format!("-L {}", dir.display()));
+    env::set_var(var_name, &format!("-L {}", dir.display()));
     env::set_var("OUT_DIR", &format!("{}", dir.display()));
 
     // Ensure HOST != TARGET.


### PR DESCRIPTION
To work around https://github.com/rust-lang/cargo/issues/10321 that occurs with cargo 1.55.0 and later.