### PR TITLE
Stateless feature probing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,6 +378,42 @@ impl AutoCfg {
             emit(cfg);
         }
     }
+
+    /// Tests whether the given features can be used.
+    ///
+    /// To ensure the features work as expected, it is highly recommended to
+    /// attempt to use the features.
+    ///
+    /// The test code is subject to change, but currently looks like:
+    ///
+    /// ```ignore
+    /// #![feature(FEATURES)]
+    /// CODE
+    /// ```
+    pub fn probe_features(&self, features: &[&str], code: &str) -> bool {
+        use std::fmt::Write;
+        let probe = &mut String::new();
+        write!(probe, "#![feature(").unwrap();
+        for feature in features {
+            write!(probe, "{},", feature).unwrap();
+        }
+        write!(probe, ")] {}", code).unwrap();
+        self.probe(probe).unwrap_or(false)
+    }
+
+    /// Emits a config value `has_FEATURE` if `probe_features` returns true.
+    pub fn emit_has_feature(&self, feature: &str, code: &str) {
+        if self.probe_features(&[feature], code) {
+            emit(&format!("has_{}", feature));
+        }
+    }
+
+    /// Emits the given `cfg` value if `probe_features` returns true.
+    pub fn emit_features_cfg(&self, features: &[&str], code: &str, cfg: &str) {
+        if self.probe_features(features, code) {
+            emit(cfg)
+        }
+    }
 }
 
 fn mangle(s: &str) -> String {


### PR DESCRIPTION
Alternative to #35. cc #24, #28.

This API puts the burden onto the user to know how to best check that a feature works as expected (whatever statements are used to check it) rather than reusing existing `probe_`/`emit_` methods. This means that `probe_features` is a bit harder to use, but the developer testing for the feature(s) almost certainly already knows what they want to do with the feature well enough to write a simple check.