### PR TITLE
probe with_features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ pub struct AutoCfg {
     rustc_version: Version,
     target: Option<OsString>,
     no_std: bool,
+    features: Vec<String>,
     rustflags: Vec<String>,
 }
 
@@ -172,6 +173,7 @@ impl AutoCfg {
             rustc: rustc,
             rustc_version: rustc_version,
             target: target,
+            features: Vec::new(),
             no_std: false,
         };
 
@@ -228,6 +230,11 @@ impl AutoCfg {
 
         if self.no_std {
             try!(stdin.write_all(b"#![no_std]\n").map_err(error::from_io));
+        }
+        for feature in &self.features {
+            try!(stdin
+                .write_all(format!("#![feature({})]\n", feature).as_bytes())
+                .map_err(error::from_io));
         }
         try!(stdin.write_all(code.as_ref()).map_err(error::from_io));
         drop(stdin);
@@ -377,6 +384,16 @@ impl AutoCfg {
         if self.probe_constant(expr) {
             emit(cfg);
         }
+    }
+
+    /// Run some autocfg probes with a set of features enabled.
+    ///
+    /// This adds `#![feature(FEATURE)]` to the start of all probes done with
+    /// the callback's `AutoCfg` for each enabled feature.
+    pub fn with_features<F: for<'a> FnOnce(&'a mut AutoCfg)>(&mut self, features: &[&str], f: F) {
+        self.features.extend(features.iter().map(|s| s.to_string()));
+        f(self);
+        self.features.truncate(self.features.len() - features.len());
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,8 @@
 use super::AutoCfg;
 use std::env;
 use std::path::Path;
+use std::process::Command;
+use std::str;
 
 impl AutoCfg {
     fn core_std(&self, path: &str) -> String {
@@ -21,6 +23,32 @@ impl AutoCfg {
             Some(d) => Self::with_dir(d),
             None => Self::with_dir("target"),
         }
+    }
+
+    fn assert_nightly(&self, probe_result: bool) {
+        // Get rustc's verbose version
+        let output = Command::new(&self.rustc)
+            .args(&["--version", "--verbose"])
+            .output()
+            .unwrap();
+        if !output.status.success() {
+            panic!("could not execute rustc")
+        }
+        let output = str::from_utf8(&output.stdout).unwrap();
+
+        // Find the release line in the verbose version output.
+        let release = match output.lines().find(|line| line.starts_with("release: ")) {
+            Some(line) => &line["release: ".len()..],
+            None => panic!("could not find rustc release"),
+        };
+
+        // Check for nightly channel info, e.g. "-nightly", "-dev"
+        let nightly = match release.find('-') {
+            Some(i) => &release[i..] == "-nightly" || &release[i..] == "-dev",
+            None => false,
+        };
+
+        assert_eq!(nightly, probe_result);
     }
 }
 
@@ -131,6 +159,23 @@ fn probe_constant() {
     assert!(ac.probe_constant("1 + 2 + 3"));
     ac.assert_min(1, 33, ac.probe_constant("{ let x = 1 + 2 + 3; x * x }"));
     ac.assert_min(1, 39, ac.probe_constant(r#""test".len()"#));
+}
+
+#[test]
+fn prope_feature() {
+    let mut ac = AutoCfg::for_test().unwrap();
+    // an empty #![features()] has no effect
+    ac.with_features(&[], |ac| {
+        assert!(ac.probe("").unwrap_or(false));
+    });
+    // stabilized feature succeeds
+    ac.with_features(&["rust1"], |ac| {
+        ac.assert_nightly(ac.probe("").unwrap_or(false));
+    });
+    // fake feature fails
+    ac.with_features(&["RUSTC_DONT_MAKE_ME_A_LIAR"], |ac| {
+        ac.assert_nightly(!ac.probe("").unwrap_or(false));
+    });
 }
 
 #[test]


### PR DESCRIPTION
Alternative to #35, #42. cc #24, #28.

This implements the callback based `with_features` approach mentioned in #35.

I've written the test to just use `.probe("")` to avoid making the test depend on the success of other tests.