### PR TITLE
--cap-lints=allow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,11 @@ impl AutoCfg {
             .arg(&self.out_dir)
             .arg("--emit=llvm-ir");
 
+        let can_cap_lints = self.probe_rustc_version(1, 3);
+        if can_cap_lints {
+            command.arg("--cap-lints=allow");
+        }
+
         if let Some(target) = self.target.as_ref() {
             command.arg("--target").arg(target);
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -134,6 +134,12 @@ fn probe_constant() {
 }
 
 #[test]
+fn cap_lints() {
+    let ac = AutoCfg::for_test().unwrap();
+    ac.assert_min(1, 3, ac.probe_constant("1000u8"));
+}
+
+#[test]
 fn dir_does_not_contain_target() {
     assert!(!super::dir_contains_target(
         &Some("x86_64-unknown-linux-gnu".into()),


### PR DESCRIPTION
Closes #41.

There *is* a tradeoff here: this means that a probe can no longer test if something is denied by a lint rather than a hard error. However, I think this is the right default.