### PR TITLE
Update and simplify the CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -42,12 +40,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: thumbv6m-none-eabi
-          profile: minimal
-          override: true
       - name: Test
         env:
           TARGET: thumbv6m-none-eabi
@@ -64,11 +59,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Install
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Test
         env:
           TARGET: thumbv6m-none-eabi
@@ -84,14 +75,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.62.0
         with:
-          profile: minimal
-          toolchain: 1.58.1
-          override: true
           components: rustfmt
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --all --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,56 +15,43 @@ jobs:
         rust: [1.0.0, 1.5.0, 1.10.0, 1.15.0, 1.20.0, 1.25.0, 1.30.0, 1.35.0,
                1.40.0, 1.45.0, 1.50.0, 1.55.0, stable, beta, nightly]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - name: Build
-        run: cargo build --verbose
-      - name: Test
-        run: cargo test --verbose
+      - run: cargo build --verbose
+      - run: cargo test --verbose
 
   # try probing a target that doesn't have std at all
   no_std:
     name: No Std
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Install
-        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           target: thumbv6m-none-eabi
-      - name: Test
+      - run: cargo test --verbose --lib
         env:
           TARGET: thumbv6m-none-eabi
-        run: cargo test --verbose --lib
 
   # we don't even need an installed target for version checks
   missing_target:
     name: Missing Target
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Install
-        uses: dtolnay/rust-toolchain@stable
-      - name: Test
+      - uses: actions/checkout@v1
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --verbose --lib -- version
         env:
           TARGET: thumbv6m-none-eabi
-        run: cargo test --verbose --lib -- version
 
   fmt:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install
-        uses: dtolnay/rust-toolchain@1.62.0
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.62.0
         with:
           components: rustfmt
-      - name: Check formatting
-        run: cargo fmt --all --check
+      - run: cargo fmt --all --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,15 +22,9 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose
+        run: cargo build --verbose
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
+        run: cargo test --verbose
 
   # try probing a target that doesn't have std at all
   no_std:
@@ -46,10 +40,7 @@ jobs:
       - name: Test
         env:
           TARGET: thumbv6m-none-eabi
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --lib
+        run: cargo test --verbose --lib
 
   # we don't even need an installed target for version checks
   missing_target:
@@ -63,10 +54,7 @@ jobs:
       - name: Test
         env:
           TARGET: thumbv6m-none-eabi
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --lib -- version
+        run: cargo test --verbose --lib -- version
 
   fmt:
     name: Format
@@ -79,7 +67,4 @@ jobs:
         with:
           components: rustfmt
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all --check
+        run: cargo fmt --all --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
                1.40.0, 1.45.0, 1.50.0, 1.55.0, stable, beta, nightly]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install
         uses: actions-rs/toolchain@v1
         with:
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         rust: [1.0.0, 1.5.0, 1.10.0, 1.15.0, 1.20.0, 1.25.0, 1.30.0, 1.35.0,
-               1.40.0, 1.45.0, 1.50.0, 1.55.0, stable, beta, nightly]
+               1.40.0, 1.45.0, 1.50.0, 1.55.0, 1.60.0, stable, beta, nightly]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -16,7 +16,7 @@ jobs:
         rust: [1.0.0, stable]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -22,12 +22,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose
+        run: cargo build --verbose
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
+        run: cargo test --verbose

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -15,13 +15,9 @@ jobs:
       matrix:
         rust: [1.0.0, stable]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - name: Build
-        run: cargo build --verbose
-      - name: Test
-        run: cargo test --verbose
+      - run: cargo build --verbose
+      - run: cargo test --verbose

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -18,11 +18,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,26 +11,19 @@ jobs:
       matrix:
         rust: [1.0.0, stable]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - name: Build
-        run: cargo build --verbose
-      - name: Test
-        run: cargo test --verbose
+      - run: cargo build --verbose
+      - run: cargo test --verbose
 
   fmt:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install
-        uses: dtolnay/rust-toolchain@1.62.0
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.62.0
         with:
           components: rustfmt
-      - name: Check formatting
-        run: cargo fmt --all --check
+      - run: cargo fmt --all --check

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,15 +18,9 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose
+        run: cargo build --verbose
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
+        run: cargo test --verbose
 
   fmt:
     name: Format
@@ -39,7 +33,4 @@ jobs:
         with:
           components: rustfmt
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all --check
+        run: cargo fmt --all --check

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,11 +14,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -37,14 +35,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.62.0
         with:
-          profile: minimal
-          toolchain: 1.58.1
-          override: true
           components: rustfmt
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --all --check

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ jobs:
         rust: [1.0.0, stable]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install
         uses: actions-rs/toolchain@v1
         with:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install
         uses: actions-rs/toolchain@v1
         with:

--- a/bors.toml
+++ b/bors.toml
@@ -11,6 +11,7 @@ status = [
   "Test (1.45.0)",
   "Test (1.50.0)",
   "Test (1.55.0)",
+  "Test (1.60.0)",
   "Test (stable)",
   "Test (beta)",
   "Test (nightly)",


### PR DESCRIPTION
- Update to actions/checkout@v3
- Switch from actions-rs/toolchain to dtolnay/rust-toolchain
- Switch from actions-rs/cargo to plain run
- Stop explicitly naming CI steps
- Add 1.60.0 to the test matrix
