### PR TITLE
Add documentation link to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.1.0"
 authors = ["Josh Stone <cuviper@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/cuviper/autocfg"
+documentation = "https://docs.rs/autocfg/"
 description = "Automatic cfg for Rust compiler features"
 readme = "README.md"
 keywords = ["rustc", "build", "autoconf"]


### PR DESCRIPTION
Crates.io generates its link to the documentation from this value.