### PR TITLE
Release 1.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Josh Stone <cuviper@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/cuviper/autocfg"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ should only be used when the compiler supports it.
 
 ## Release Notes
 
+- 1.2.0 (2024-03-25)
+
+  - Add `no_std` and `set_no_std` to control the use of `#![no_std]` in probes.
+  - Use `RUSTC_WRAPPER` and `RUSTC_WORKSPACE_WRAPPER` when they are set.
+
 - 1.1.0 (2022-02-07)
   - Use `CARGO_ENCODED_RUSTFLAGS` when it is set.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,7 +447,7 @@ fn dir_contains_target(
 
                 cargo_target_dir
                     .to_str()
-                    .map(|cargo_target_dir| dir.contains(&cargo_target_dir))
+                    .map(|cargo_target_dir| dir.contains(cargo_target_dir))
             })
         })
         .unwrap_or(false)


### PR DESCRIPTION
- **Release 1.2.0**
- **Fix `clippy::needless_borrows_for_generic_args`**
