### PR TITLE
Add `AutoCfg::probe_raw` for free-form probes

### DIFF
--- a/examples/nightly.rs
+++ b/examples/nightly.rs
@@ -1,0 +1,18 @@
+extern crate autocfg;
+
+fn main() {
+    // Normally, cargo will set `OUT_DIR` for build scripts.
+    let ac = autocfg::AutoCfg::with_dir("target").unwrap();
+
+    // When this feature was stabilized, it also renamed the method to
+    // `chunk_by`, so it's important to *use* the feature in your probe.
+    let code = r#"
+        #![feature(slice_group_by)]
+        pub fn probe(slice: &[i32]) -> impl Iterator<Item = &[i32]> {
+            slice.group_by(|a, b| a == b)
+        }
+    "#;
+    if ac.probe_raw(code).is_ok() {
+        autocfg::emit("has_slice_group_by");
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -134,6 +134,18 @@ fn probe_constant() {
 }
 
 #[test]
+fn probe_raw() {
+    let ac = AutoCfg::for_test().unwrap();
+
+    // This attribute **must** be used at the crate level.
+    assert!(ac.probe_raw("#![no_builtins]").is_ok());
+
+    assert!(ac.probe_raw("#![deny(dead_code)] fn x() {}").is_err());
+    assert!(ac.probe_raw("#![allow(dead_code)] fn x() {}").is_ok());
+    assert!(ac.probe_raw("#![deny(dead_code)] pub fn x() {}").is_ok());
+}
+
+#[test]
 fn dir_does_not_contain_target() {
     assert!(!super::dir_contains_target(
         &Some("x86_64-unknown-linux-gnu".into()),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -136,13 +136,17 @@ fn probe_constant() {
 #[test]
 fn probe_raw() {
     let ac = AutoCfg::for_test().unwrap();
+    let prefix = if ac.no_std { "#![no_std]\n" } else { "" };
+    let f = |s| format!("{}{}", prefix, s);
 
     // This attribute **must** be used at the crate level.
-    assert!(ac.probe_raw("#![no_builtins]").is_ok());
+    assert!(ac.probe_raw(&f("#![no_builtins]")).is_ok());
 
-    assert!(ac.probe_raw("#![deny(dead_code)] fn x() {}").is_err());
-    assert!(ac.probe_raw("#![allow(dead_code)] fn x() {}").is_ok());
-    assert!(ac.probe_raw("#![deny(dead_code)] pub fn x() {}").is_ok());
+    assert!(ac.probe_raw(&f("#![deny(dead_code)] fn x() {}")).is_err());
+    assert!(ac.probe_raw(&f("#![allow(dead_code)] fn x() {}")).is_ok());
+    assert!(ac
+        .probe_raw(&f("#![deny(dead_code)] pub fn x() {}"))
+        .is_ok());
 }
 
 #[test]


### PR DESCRIPTION
This takes an arbitrary string that will be fed to the compiler as-is,
without even interjecting `#![no_std]` like other probe methods. It also
returns a `Result` with the full `Error`, so you could choose to print
verbose details on failure, for example.

Resolves #24.