### PR TITLE
Release 1.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Josh Stone <cuviper@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/cuviper/autocfg"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ should only be used when the compiler supports it.
 
 ## Release Notes
 
+- 1.3.0 (2024-05-03)
+
+  - Add `probe_raw` for direct control of the code that will be test-compiled.
+  - Use wrappers when querying the `rustc` version information too.
+
 - 1.2.0 (2024-03-25)
 
   - Add `no_std` and `set_no_std` to control the use of `#![no_std]` in probes.


### PR DESCRIPTION
  - Add `probe_raw` for direct control of the code that will be test-compiled.
  - Use wrappers when querying the `rustc` version information too.