### PR TITLE
Automatically emit `rustc-check-cfg` directives for AutoCfg

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         rust: [1.0.0, 1.5.0, 1.10.0, 1.15.0, 1.20.0, 1.25.0, 1.30.0, 1.35.0,
                1.40.0, 1.45.0, 1.50.0, 1.55.0, 1.60.0, 1.65.0, 1.70.0, 1.75.0,
+               1.80.0, # first version with rustc-check-cfg
                stable, beta, nightly]
     steps:
       - uses: actions/checkout@v4
@@ -22,6 +23,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - run: cargo build --verbose
       - run: cargo test --verbose
+      - run: cargo run
+        working-directory: ./ci/verify-check-cfg
 
   # try probing a target that doesn't have std at all
   no_std:

--- a/ci/verify-check-cfg/.gitignore
+++ b/ci/verify-check-cfg/.gitignore
@@ -1,0 +1,3 @@
+# Rust
+/target
+/Cargo.lock

--- a/ci/verify-check-cfg/Cargo.toml
+++ b/ci/verify-check-cfg/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2015"
 # only for testing
 publish = false
 
+build = "build.rs"
+
 [build-dependencies]
 autocfg = { path = "../.." }
 

--- a/ci/verify-check-cfg/Cargo.toml
+++ b/ci/verify-check-cfg/Cargo.toml
@@ -3,7 +3,7 @@
 name = "autocfg-verify-check-cfg"
 description = "A dummy crate to verify autocfg is emitting check-cfg directives"
 version = "0.1.0"
-edition = "2021"
+edition = "2015"
 # only for testing
 publish = false
 

--- a/ci/verify-check-cfg/Cargo.toml
+++ b/ci/verify-check-cfg/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+# NOTE: Cannot be in workspace because of rustc 1.0 support
+name = "autocfg-verify-check-cfg"
+description = "A dummy crate to verify autocfg is emitting check-cfg directives"
+version = "0.1.0"
+edition = "2021"
+# only for testing
+publish = false
+
+[build-dependencies]
+autocfg = { path = "../.." }
+

--- a/ci/verify-check-cfg/build.rs
+++ b/ci/verify-check-cfg/build.rs
@@ -1,3 +1,5 @@
+extern crate autocfg;
+
 pub fn main() {
     let cfg = autocfg::AutoCfg::new().unwrap();
 
@@ -8,7 +10,7 @@ pub fn main() {
     // always true
     cfg.emit_rustc_version(1, 0);
     // should always be false
-    cfg.emit_rustc_version(7, u32::MAX as usize);
+    cfg.emit_rustc_version(7, std::u32::MAX as usize);
 
     // always true
     cfg.emit_has_path("std::vec::Vec");

--- a/ci/verify-check-cfg/build.rs
+++ b/ci/verify-check-cfg/build.rs
@@ -1,0 +1,43 @@
+pub fn main() {
+    let cfg = autocfg::AutoCfg::new().unwrap();
+
+    //
+    // tests
+    //
+
+    // always true
+    cfg.emit_rustc_version(1, 0);
+    // should always be false
+    cfg.emit_rustc_version(7, u32::MAX as usize);
+
+    // always true
+    cfg.emit_has_path("std::vec::Vec");
+    cfg.emit_path_cfg("std::vec::Vec", "has_path_std_vec");
+    // always false
+    cfg.emit_has_path("dummy::DummyPath");
+    cfg.emit_path_cfg("dummy::DummyPath", "has_path_dummy");
+
+    // always true
+    cfg.emit_has_trait("std::ops::Add");
+    cfg.emit_trait_cfg("std::ops::Add", "has_trait_add");
+    // always false
+    cfg.emit_has_trait("dummy::DummyTrait");
+    cfg.emit_trait_cfg("dummy::DummyTrait", "has_trait_dummy");
+
+    // always true
+    cfg.emit_has_type("i32");
+    cfg.emit_type_cfg("i32", "has_type_i32");
+    // always false
+    cfg.emit_has_type("i7billion");
+    cfg.emit_type_cfg("i7billion", "has_type_i7billion");
+
+    // always true
+    cfg.emit_expression_cfg("3 + 7", "has_working_addition");
+    // always false
+    cfg.emit_expression_cfg("3 ^^^^^ 12", "has_working_5xor");
+
+    // always true
+    cfg.emit_constant_cfg("7", "has_const_7");
+    // false - Opening file should never be `const`
+    cfg.emit_constant_cfg("std::fs::File::open(\"foo.txt\")", "has_const_file_open");
+}

--- a/ci/verify-check-cfg/src/main.rs
+++ b/ci/verify-check-cfg/src/main.rs
@@ -1,0 +1,42 @@
+#![deny(unexpected_cfgs)]
+
+macro_rules! test_cfgs {
+    ($($cfg:ident,)*) => {$({
+        let cfg_desc = format!("cfg!({})", stringify!($cfg));
+        if cfg!($cfg) {
+            println!("Enabled:    {}", cfg_desc);
+        } else {
+            println!("Disabled:   {}", cfg_desc);
+        }
+    })*};
+
+}
+
+pub fn main() {
+    test_cfgs!(
+        // emit_rustc_version
+        rustc_1_0,
+        rustc_7_4294967295,
+        // emit_has_path, emit_path_cfg
+        has_std__vec__Vec,
+        has_path_std_vec,
+        has_dummy__DummyPath,
+        has_path_dummy,
+        // emit_has_trait, emit_trait_cfg
+        has_std__ops__Add,
+        has_trait_add,
+        has_dummy__DummyTrait,
+        has_trait_dummy,
+        // emit_has_type, has_type_i32
+        has_i32,
+        has_type_i32,
+        has_i7billion,
+        has_type_i7billion,
+        // emit_expression_cfg
+        has_working_addition,
+        has_working_5xor,
+        // emit_constant_cfg
+        has_const_7,
+        has_const_file_open,
+    );
+}

--- a/ci/verify-check-cfg/src/main.rs
+++ b/ci/verify-check-cfg/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints)]
 #![deny(unexpected_cfgs)]
 
 macro_rules! test_cfgs {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,8 @@ pub struct AutoCfg {
 /// This does not automatically call [`emit_possibility`]
 /// so the compiler my generate an [`unexpected_cfgs` warning][check-cfg-flags].
 /// However, all the builtin emit methods on [`AutoCfg`] call [`emit_possibility`] automatically.
+///
+/// [check-cfg-flags]: https://blog.rust-lang.org/2024/05/06/check-cfg.html
 pub fn emit(cfg: &str) {
     println!("cargo:rustc-cfg={}", cfg);
 }
@@ -131,7 +133,7 @@ pub fn rerun_env(var: &str) {
 
 /// Indicates to rustc that a config flag should not generate an [`unexpected_cfgs` warning][check-cfg-flags]
 ///
-/// This looks like `cargo:cargo:rustc-check-cfg=cfg(VAR)`
+/// This looks like `cargo:rustc-check-cfg=cfg(VAR)`
 ///
 /// As of rust 1.80, the compiler does [automatic checking of cfgs at compile time][check-cfg-flags].
 /// All custom configuration flags must be known to rustc, or they will generate a warning.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,11 +395,7 @@ impl AutoCfg {
     /// Any non-identifier characters in the `path` will be replaced with
     /// `_` in the generated config value.
     pub fn emit_has_path(&self, path: &str) {
-        let cfg_flag = format!("has_{}", mangle(path));
-        emit_possibility(&cfg_flag);
-        if self.probe_path(path) {
-            emit(&cfg_flag);
-        }
+        self.emit_path_cfg(path, &format!("has_{}", mangle(path)));
     }
 
     /// Emits the given `cfg` value if `probe_path` returns true.
@@ -426,11 +422,7 @@ impl AutoCfg {
     /// Any non-identifier characters in the trait `name` will be replaced with
     /// `_` in the generated config value.
     pub fn emit_has_trait(&self, name: &str) {
-        let cfg_flag = format!("has_{}", mangle(name));
-        emit_possibility(&cfg_flag);
-        if self.probe_trait(name) {
-            emit(&cfg_flag);
-        }
+        self.emit_trait_cfg(name, &format!("has_{}", mangle(name)));
     }
 
     /// Emits the given `cfg` value if `probe_trait` returns true.
@@ -457,11 +449,7 @@ impl AutoCfg {
     /// Any non-identifier characters in the type `name` will be replaced with
     /// `_` in the generated config value.
     pub fn emit_has_type(&self, name: &str) {
-        let cfg_flag = format!("has_{}", mangle(name));
-        emit_possibility(&cfg_flag);
-        if self.probe_type(name) {
-            emit(&cfg_flag);
-        }
+        self.emit_type_cfg(name, &format!("has_{}", mangle(name)));
     }
 
     /// Emits the given `cfg` value if `probe_type` returns true.


### PR DESCRIPTION
This avoids the `unexpected_cfgs` lint for any of the configs emitted by AutoCfg methods.
This lint is new in Rust 1.80: <https://blog.rust-lang.org/2024/05/06/check-cfg.html>

This adds a `emit_possibility` method to mirror the `emit` method.
Calling `emit` manually does not call `emit_possibility`.

Fixes issue #64
